### PR TITLE
Implementa função para desenhar quadrado

### DIFF
--- a/air-hockey/main.cpp
+++ b/air-hockey/main.cpp
@@ -49,6 +49,7 @@ void draw()
     setProjection();
 
     glColor3f(BLUE[0], BLUE[1], BLUE[2]);
+
     glTranslatef(250, 350, 0);
     glScalef(15, 15, 1);
     Shapes::circle(36);

--- a/air-hockey/src/shapes.cpp
+++ b/air-hockey/src/shapes.cpp
@@ -21,3 +21,14 @@ void Shapes::circle(int divisions)
         }
     glEnd();
 }
+
+
+void Shapes::square()
+{
+    glBegin(GL_QUADS);
+        glVertex2f(-1, -1);
+        glVertex2f( 1, -1);
+        glVertex2f( 1,  1);
+        glVertex2f(-1,  1);
+    glEnd();
+}


### PR DESCRIPTION
Essa função será importante uma vez nosso jogo é composto basicamente por quadrados, retângulos e circulos. Dessa forma, vamos pode usar o quadrado para desenhar retângulo aplicando escalas não uniformes.